### PR TITLE
Add method to get filename from http response

### DIFF
--- a/streaming_urls/http.py
+++ b/streaming_urls/http.py
@@ -1,6 +1,7 @@
 import requests
 import warnings
 from functools import lru_cache
+from urllib.parse import urlparse
 
 from requests import codes
 from requests.adapters import HTTPAdapter
@@ -52,6 +53,23 @@ class Session(requests.Session):
         resp = self.get(url, stream=True)
         resp.raise_for_status()
         return resp.iter_content(chunk_size=chunk_size)
+
+    def name(self, url: str) -> str:
+        """
+        Attempt to discover a filename associated with 'url' using the foolowing methods, in order:
+        1. Parse the 'Content-Disposition' header for the 'filename' field
+        2. Use the last path component of the 'path' field returned from urllib.parse.urlparse
+        """
+        name = ""
+        content_disposition = self.head(url).get('Content-Disposition', "")
+        for part in content_disposition.split(";"):
+            if part.strip().startswith("filename"):
+                name = part.split("=", 1)[-1].strip("'\"")
+                break
+        name = name or urlparse(url).path.rsplit("/", 1)[-1]
+        if name:
+            return name
+        raise ValueError(f"Unable to extract name from url '{url}'")
 
 def http_session(session: Session=None, retry: Retry=None) -> Session:
     session = session or Session()

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -79,5 +79,34 @@ class TestHTTP(unittest.TestCase):
                 with http_session() as http:
                     self.assertEqual(expected_size, http.size(url))
 
+    def test_name(self):
+        class HeadHandler(SilentHandler):
+            content_disp = None
+
+            def do_HEAD(self, *args, **kwargs):
+                self.send_response(200)
+                if self.content_disp is not None:
+                    self.send_header("Content-Disposition", self.content_disp)
+                self.end_headers()
+
+        with ThreadedLocalServer(HeadHandler) as host:
+            with http_session() as http:
+                tests = [
+                    ("xyzy-1", "bar; filename=\"xyzy-1\"; blah", f"{host}/foof"),
+                    ("xyzy-2", "foo; bar filename=\"asf\"; blah", f"{host}/xyzy-2"),
+                    ("xyzy-3", "foo; filename=; blah", f"{host}/foo/xyzy-3"),
+                    ("xyzy-4", None, f"{host}/foo/xyzy-4"),
+                ]
+
+                for expected, content_disp, url in tests:
+                    HeadHandler.content_disp = content_disp
+                    with self.subTest(expected_name=expected, content_disp=content_disp, url=url):
+                        self.assertEqual(expected, http.name(url))
+
+                with self.subTest("Should raise if name not available"):
+                    with self.assertRaises(ValueError):
+                        url, HeadHandler.content_disp = host, None
+                        http.name(url)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This uses:
  1. The Content-Disposition header, if available
  2. The last path component of the 'path' returned by
     'urllib.parse.urlparse'